### PR TITLE
Fix dialyzer Shard module warning

### DIFF
--- a/lib/phoenix/tracker/shard.ex
+++ b/lib/phoenix/tracker/shard.ex
@@ -406,7 +406,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp clock(state), do: State.clocks(state.presences)
 
-  @spec clockset_to_sync(t) :: [State.replica_name]
+  @spec clockset_to_sync(t) :: [State.name]
   defp clockset_to_sync(state) do
     my_ref = Replica.ref(state.replica)
 


### PR DESCRIPTION
The changes fix the following dialyzer warning:

```
lib/phoenix/tracker/shard.ex:409:38:unknown_type
Unknown type: Phoenix.Tracker.State.replica_name/0.
```

According to the functions flow, `clockset_replicas` returns `[State.name]`

https://github.com/phoenixframework/phoenix_pubsub/blob/main/lib/phoenix/tracker/clock.ex#L11-L11